### PR TITLE
Add support for <SID>

### DIFF
--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -14,7 +14,7 @@ function! lookup#lookup() abort
   let &iskeyword = isk
   let is_func = name =~ '($' ? 1 : 0
   let could_be_funcref = name =~ '[''"]$' ? 1 : 0
-  let name = matchstr(name, '\v^%(s:|\<sid\>)?\zs.{-}\ze[\("'']?$')
+  let name = matchstr(name, '\v^%(s:|\<sid\>|\<SID\>)?\zs.{-}\ze[\("'']?$')
   let is_auto = name =~ '#' ? 1 : 0
   let position = s:getcurpos()
   if !dispatch[is_auto][is_func](name) && !is_func && could_be_funcref
@@ -44,7 +44,7 @@ endfunction
 
 " s:find_local_func_def() {{{1
 function! s:find_local_func_def(funcname) abort
-  if search('\c\v<fu%[nction]!?\s+%(s:|\<sid\>)\zs\V'.a:funcname.'\>', 'bsw') != 0
+  if search('\c\v<fu%[nction]!?\s+%(s:|\<sid\>|\<SID\>)\zs\V'.a:funcname.'\>', 'bsw') != 0
     return
   endif
 


### PR DESCRIPTION
test with:
```vim
fu! s:test()
endf

let test = <SID>test()
```

cursor is on `<SID>test()`