### PR TITLE
fix function jump

### DIFF
--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -58,7 +58,13 @@ function! s:find_local_func_def(funcname) abort
     return
   endif
 
-  execute 'edit' substitute(split(funcloc, '\n')[1], '.*Last set from \ze', '', '')
+  let match = substitute(split(funcloc, '\n')[1], '.*Last set from \ze', '', '')
+  let file = substitute(match, ' line [0-9]\+$', '', 'g')
+  let line = substitute(match, ' line \([0-9]\+\)$', '\1', 'g')
+  execute 'edit' file
+  let cursorpos = getpos('.')
+  let cursorpos[1] = line
+  call setpos('.', cursorpos)
 
   let fn = substitute(a:funcname, '^g:', '', '')
   call search('\c\v<fu%[nction]!?\s+%(g:)?\zs\V'.fn.'\>', 'bsw')

--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -58,13 +58,9 @@ function! s:find_local_func_def(funcname) abort
     return
   endif
 
-  let match = substitute(split(funcloc, '\n')[1], '.*Last set from \ze', '', '')
-  let file = substitute(match, ' line [0-9]\+$', '', 'g')
-  let line = substitute(match, ' line \([0-9]\+\)$', '\1', 'g')
+  let file = substitute(split(funcloc, '\n')[1], '.*Last set from \ze', '', '')
+  let file = substitute(file, ' line [0-9]\+$', '', 'g')
   execute 'edit' file
-  let cursorpos = getpos('.')
-  let cursorpos[1] = line
-  call setpos('.', cursorpos)
 
   let fn = substitute(a:funcname, '^g:', '', '')
   call search('\c\v<fu%[nction]!?\s+%(g:)?\zs\V'.fn.'\>', 'bsw')


### PR DESCRIPTION
problem:

the function jump would result this command:
* `:edit file_name line 123`

which would result to edit a new file named `file_name line 123`

---

solve:

split the command to
* `:edit file_name` 
* `call setpos('.', [xxx, 123, xxx, xxx])`