### PR TITLE
Add support for commands; use the line number provided by vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # vim-lookup
 
-This plugin is meant for VimL programmers. It jumps to definitions of variables
-or functions, as if tags were used, without needing a tags file. It simply
+This plugin is meant for VimL programmers. It jumps to definitions of variables,
+functions, and commands as if tags were used, without needing a tags file. It simply
 uses your [runtimepath](https://neovim.io/doc/user/options.html#'rtp').
 
 - [x] `s:var`
@@ -12,6 +12,7 @@ uses your [runtimepath](https://neovim.io/doc/user/options.html#'rtp').
 - [x] `autoload#foo#var`
 - [x] `autoload#foo#func()`
 - [x] `'autoload#foo#func'`
+- [x] `Command`
 
 Sometimes a function `foo#func()` is not found in `autoload/foo.vim` but
 `plugin/foo.vim`. This case is handled as well.

--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -88,7 +88,8 @@ function! s:jump_to_file_defining(symbol_type, symbol_name) abort
     return
   endif
 
-  execute 'silent! edit' matchstr(location, '.*Last set from \zs.*\ze line \d\+$')
+  let matches = matchlist(location, '\v.*Last set from (.*) line (\d+)>')
+  execute 'silent! edit +'. matches[2] matches[1]
 endfunction
 
 " s:find_local_var_def() {{{1

--- a/test/tests/command.vader
+++ b/test/tests/command.vader
@@ -1,0 +1,22 @@
+Given vim:
+  command! -nargs=+    TestIt call s:func(<f-args>)
+  execute "command! -nargs=0    TestFlip let s:var = 'hello'"
+  execute 'let s:var = "bar"'
+  echomsg s:var
+  function! s:nested(a, b)
+    TestIt
+    TestFlip
+  endfunc
+
+Execute (:call lookup#lookup() to find definition of commands):
+  " on TestIt
+  normal! 6G
+  AssertEqual [6, 3], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [1, 22], [line('.'), col('.')]
+
+  " on TestFlip
+  normal! 7G
+  call lookup#lookup()
+  AssertEqual [2, 31], [line('.'), col('.')]
+


### PR DESCRIPTION
Each commit could be a separate PR, but that feels excessive. Let me know if you want them split.

Commands are pretty much as easy as functions, so I refactored some code. I couldn't figure out a more elegant way to fit it into the dispatch system (which seems to be premised on there being two symmetrical options), so I just put it at the top.

Use the line number provided by vim. I think this should help in situations where the same function is [defined multiple times in a file](https://github.com/prabirshrestha/vim-lsp/blob/8c5ee44eee119e59aa1c7d8a82f082ee21096f28/autoload/lsp/utils/tagstack.vim#L1) -- it will use the actual one in use.