### PR TITLE
Add actual taglist support (settagstack)

### DIFF
--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -23,7 +23,7 @@ function! lookup#lookup() abort
   endif
   let didmove = position != s:getcurpos() ? 1 : 0
   if didmove
-    call s:push(position)
+    call s:push(position, name)
   else
     echo 'No match'
     return 0
@@ -42,7 +42,7 @@ function! lookup#pop()
   endif
   let pos = remove(w:lookup_stack, 0)
   execute 'silent!' (bufexists(pos[0]) ? 'buffer' : 'edit') fnameescape(pos[0])
-  call cursor(pos[1:])
+  call cursor(pos[2:])
 endfunction
 
 " s:find_local_func_def() {{{1
@@ -115,7 +115,8 @@ function! s:find_autoload_def(name, pattern) abort
 endfunction
 
 " s:push() {{{1
-function! s:push(position) abort
+function! s:push(position, tagname) abort
+  call s:pushtagstack(a:position[1:], a:tagname)
   if !has_key(w:, 'lookup_stack') || empty(w:lookup_stack)
     let w:lookup_stack = [a:position]
     return
@@ -125,7 +126,22 @@ function! s:push(position) abort
   endif
 endfunction
 
+" s:pushtagstack() {{{1
+function! s:pushtagstack(curpos, tagname) abort
+    if !exists('*gettagstack') || !exists('*settagstack')
+        " do nothing
+        return
+    endif
+
+    let item = {'bufnr': a:curpos[0], 'from': a:curpos, 'tagname': a:tagname}
+
+    let winid = win_getid()
+    let stack = gettagstack(winid)
+    let stack['items'] = [item]
+    call settagstack(winid, stack, 't')
+endfunction
+
 " s:getcurpos() {{{1
 function! s:getcurpos() abort
-  return [expand('%:p')] + getcurpos()[1:]
+  return [expand('%:p')] + getcurpos()
 endfunction


### PR DESCRIPTION
Now vimscript tag jumps show up in :tags and related commands.
lookup#pop functions as before.