### PR TITLE
Add actual tag stack support (settagstack)

### DIFF
--- a/autoload/lookup.vim
+++ b/autoload/lookup.vim
@@ -23,7 +23,7 @@ function! lookup#lookup() abort
   endif
   let didmove = position != s:getcurpos() ? 1 : 0
   if didmove
-    call s:push(position)
+    call s:push(position, name)
   else
     echo 'No match'
     return 0
@@ -42,7 +42,7 @@ function! lookup#pop()
   endif
   let pos = remove(w:lookup_stack, 0)
   execute 'silent!' (bufexists(pos[0]) ? 'buffer' : 'edit') fnameescape(pos[0])
-  call cursor(pos[1:])
+  call cursor(pos[2:])
 endfunction
 
 " s:find_local_func_def() {{{1
@@ -115,7 +115,8 @@ function! s:find_autoload_def(name, pattern) abort
 endfunction
 
 " s:push() {{{1
-function! s:push(position) abort
+function! s:push(position, tagname) abort
+  call s:pushtagstack(a:position[1:], a:tagname)
   if !has_key(w:, 'lookup_stack') || empty(w:lookup_stack)
     let w:lookup_stack = [a:position]
     return
@@ -125,7 +126,25 @@ function! s:push(position) abort
   endif
 endfunction
 
+" s:pushtagstack() {{{1
+function! s:pushtagstack(curpos, tagname) abort
+    if !exists('*gettagstack') || !exists('*settagstack') || !has('patch-8.2.0077') " patch that adds 't' argument
+        " do nothing
+        return
+    endif
+
+    let item = {'bufnr': a:curpos[0], 'from': a:curpos, 'tagname': a:tagname}
+
+    let winid = win_getid()
+    let stack = gettagstack(winid)
+    let stack['items'] = [item]
+    call settagstack(winid, stack, 't')
+endfunction
+
 " s:getcurpos() {{{1
 function! s:getcurpos() abort
-  return [expand('%:p')] + getcurpos()[1:]
+  let pos = getcurpos()
+  " getcurpos always returns bufnr 0.
+  let pos[0] = bufnr('%')
+  return [expand('%:p')] + pos
 endfunction

--- a/test/tests/tagstack.vader
+++ b/test/tests/tagstack.vader
@@ -1,0 +1,108 @@
+Given vim:
+  function! s:func(a, b)
+    return s:nested(a, b)
+  endfunc
+  execute 'let s:var = "bar"'
+  let s:const = "foo"
+  echomsg s:var
+  function! s:nested(a, b)
+    return [s:var + a:a, s:const + a:b]
+  endfunc
+
+Execute (lookup#lookup() a couple levels deep and C-t to go back):
+  " on s:nested
+  normal! 2G4e
+  AssertEqual [2, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [7, 13], [line('.'), col('.')]
+
+  " on s:var
+  normal! j
+  AssertEqual [8, 13], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [4, 16], [line('.'), col('.')]
+  exec "normal! \<C-t>"
+  AssertEqual [8, 13], [line('.'), col('.')]
+
+  " on s:const
+  normal! fc
+  AssertEqual [8, 26], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [5, 7], [line('.'), col('.')]
+  exec "normal! \<C-t>"
+  AssertEqual [8, 26], [line('.'), col('.')]
+
+  exec "normal! \<C-t>"
+  AssertEqual [2, 17], [line('.'), col('.')]
+
+
+Execute (lookup#lookup() a couple levels deep and lookup#pop to go back):
+  " on s:nested
+  normal! 2G4e
+  AssertEqual [2, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [7, 13], [line('.'), col('.')]
+
+  " on s:var
+  normal! j
+  AssertEqual [8, 13], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [4, 16], [line('.'), col('.')]
+  call lookup#pop()
+  AssertEqual [8, 13], [line('.'), col('.')]
+
+  " on s:const
+  normal! fc
+  AssertEqual [8, 26], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual [5, 7], [line('.'), col('.')]
+  call lookup#pop()
+  AssertEqual [8, 26], [line('.'), col('.')]
+
+  call lookup#pop()
+  AssertEqual [2, 17], [line('.'), col('.')]
+
+
+Execute (lookup#lookup() across files and C-t to go back):
+  edit fixture/plugin/auto.vim
+  normal! 5G^3w
+  AssertEqual [5, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual expand('fixture/autoload/auto/foo.vim'), expand('%')
+  AssertEqual [5, 5], [line('.'), col('.')]
+  exec "normal! \<C-t>"
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [5, 17], [line('.'), col('.')]
+
+  normal! k
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [4, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual expand('fixture/autoload/auto/foo.vim'), expand('%')
+  AssertEqual [5, 5], [line('.'), col('.')]
+  exec "normal! \<C-t>"
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [4, 17], [line('.'), col('.')]
+
+
+Execute (lookup#lookup() across files and lookup#pop to go back):
+  edit fixture/plugin/auto.vim
+  normal! 5G^3w
+  AssertEqual [5, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual expand('fixture/autoload/auto/foo.vim'), expand('%')
+  AssertEqual [5, 5], [line('.'), col('.')]
+  call lookup#pop()
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [5, 17], [line('.'), col('.')]
+
+  normal! k
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [4, 17], [line('.'), col('.')]
+  call lookup#lookup()
+  AssertEqual expand('fixture/autoload/auto/foo.vim'), expand('%')
+  AssertEqual [5, 5], [line('.'), col('.')]
+  call lookup#pop()
+  AssertEqual expand('fixture/plugin/auto.vim'), expand('%')
+  AssertEqual [4, 17], [line('.'), col('.')]
+


### PR DESCRIPTION
Now vimscript tag jumps show up in :tags and related commands.
lookup#pop functions as before.

This also allows multiple tag stacks -- one per window instead of one
global tag stack. So C-t will behave more consistently than the version
mapped to lookup#pop.

Not sure what was wrong yesterday, so I included a test for C-t (and lookup#pop for good measure).